### PR TITLE
fix latest yml to use the latest kernel gateway

### DIFF
--- a/gateway/insights-base-latest.yml
+++ b/gateway/insights-base-latest.yml
@@ -5,7 +5,7 @@ channels:
   - esri
 dependencies:
   - python=3.7
-  - jupyter_kernel_gateway=2.1.0
+  - jupyter_kernel_gateway
   - pandas
   - numpy
   - shapely


### PR DESCRIPTION
A bug has been introduced in the `Notebook=6.1` which gets installed as a dependency with the Jupyter kernel gateway when our conda environment is created. 

When you connect to the gateway url in your Insights desktop application, it will connect and then the scripting environment blows up when you choose either a Python3 or R kernel from the dropdown. This is due to the above bug and it gives you the following error message in the terminal where you have started your kernel gateway.

```
[W timestamp] 404 POST /api/kernels (127.0.0.1): Kernel does not exist: <coroutine object MappingKernelManager.start_kernel at 0x7fa59cc079e0>
[W timestamp] 404 POST /api/kernels (127.0.0.1) 1.10ms /Users/xxx/opt/anaconda3/envs/insights-base/lib/python3.7/asyncio/base_events.py:1771: RuntimeWarning: coroutine 'MappingKernelManager.start_kernel' was never awaited
 handle = self._ready.popleft()
RuntimeWarning: Enable tracemalloc to get the object allocation traceback
```

This issue was fixed [here](https://github.com/jupyter/kernel_gateway/pull/338) in Jupyter Kernel Gateway 2.4.2 version.

Updating the kernel gateway to its latest version fixes this problem. 