### PR TITLE
Update latest yml

### DIFF
--- a/gateway/insights-latest.yml
+++ b/gateway/insights-latest.yml
@@ -2,7 +2,6 @@
 name: insights-latest
 channels:
   - conda-forge
-  - esri
 dependencies:
   - python=3.7
   - jupyter_kernel_gateway
@@ -13,7 +12,6 @@ dependencies:
   - msgpack-python
   - matplotlib
   - geopandas
-  - arcgis
   - r-itertools
   - r-essentials
   - pyspark


### PR DESCRIPTION
Remove `esri` channel as it's causing unnecessary conflicts with the dependent packages of geopandas (Geopandas requires all it's dependencies to be installed from a single channel to avoid version conflicts when conda resolves the environment during creation). We don't use Esri channel or arcgis library in our InsightsPy API.